### PR TITLE
Fixed Regex Searching, Typo in README.md, New Hosts & Minor Changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,3 @@
 # IGGScraper
 A web scraper for igg-games.com written in Python 3 that provides direct download links of any specified game. 
-Quick and easy to use. Build with urllib and BeautifulSoup. 
+Quick and easy to use. Built with urllib and BeautifulSoup. 

--- a/igg_scraper.py
+++ b/igg_scraper.py
@@ -1,5 +1,4 @@
-
-#credit tingtingths https://greasyfork.org/en/scripts/423435-igg-games-bluemediafiles-bypass/code
+# credit tingtingths https://greasyfork.org/en/scripts/423435-igg-games-bluemediafiles-bypass/code
 def _bluemediafiles_decodeKey(encoded):
     key = ''
     i = int(len(encoded) / 2 - 5)
@@ -7,7 +6,7 @@ def _bluemediafiles_decodeKey(encoded):
         key += encoded[i]
         i = i - 2
     i = int(len(encoded) / 2 + 4)
-    while(i < len(encoded)):
+    while i < len(encoded):
         key += encoded[i]
         i = i + 2
     return key
@@ -35,18 +34,19 @@ def main():
     )
 
     possible_sources = ["MegaUp.net", "Rapidgator", "Mega.co.nz", "Mega.nz", "Openload.co", "KumpulBagi",
-                        "UpFile", "FileCDN", "Go4Up (Multi Links)", "Uploaded", "Uptobox", "Google Drive"]  # Download Sources
+                        "UpFile", "FileCDN", "Go4Up (Multi Links)", "Uploaded", "Uptobox",
+                        "Google Drive", "1Fichier", "Direct", "ClicknUpload", "AnonFiles"]  # Download Sources
     existing_sources = []
 
     try:
         request = urllib.request.urlopen(req)
     except urllib.error.URLError:
-        print("Url could not be opend.")
+        print("URL could not be opened.")
         exit()
 
     soup = BeautifulSoup(request, "lxml")
 
-    for paragraph in soup.find_all("p"):
+    for paragraph in soup.find_all("b"):
         for source in possible_sources:
             if "Link " + source in paragraph.text:
                 existing_sources.append(source)
@@ -64,7 +64,7 @@ def main():
                 raise ValueError
         except ValueError:
             source_choice = input(
-                "Please enter a number between 1 and "+str(len(existing_sources)) + ": ")
+                "Please enter a number between 1 and " + str(len(existing_sources)) + ": ")
 
     finalOutput = ""
     for paragraph in soup.find_all("p"):
@@ -82,7 +82,7 @@ def main():
                 try:
                     request = urllib.request.urlopen(sec_req)
                 except urllib.error.URLError:
-                    print("Url could not be opend.")
+                    print("URL could not be opened.")
                     exit()
 
                 soup = BeautifulSoup(request, "lxml")
@@ -90,7 +90,7 @@ def main():
                 for script in soup.find_all("script"):
                     matches = re.findall(
                         r"Goroi_n_Create_Button\(\"(.*?)\"\)", str(script))
-                    if(len(matches) > 0):
+                    if len(matches) > 0:
                         string = 'https://bluemediafiles.com/get-url.php?url=' + _bluemediafiles_decodeKey(matches[0])
                         third_req = urllib.request.Request(
                             string,
@@ -102,14 +102,14 @@ def main():
                         try:
                             request = urllib.request.urlopen(third_req)
                         except urllib.error.URLError:
-                            print("Url could not be opend.")
+                            print("URL could not be opened.")
                             exit()
                         print(request.geturl())
                         finalOutput += request.geturl() + "\n"
 
             print("\n")
-            if (input("Copy to Clipboard? y/n ").lower() == "y"):
+            if input("Copy to Clipboard? y/n ").lower() == "y":
                 pyperclip.copy(finalOutput)
 
-
+                
 main()

--- a/igg_scraper.py
+++ b/igg_scraper.py
@@ -33,7 +33,7 @@ def main():
         }
     )
 
-    possible_sources = ["MegaUp.net", "Rapidgator", "Mega.co.nz", "Mega.nz", "Openload.co", "KumpulBagi",
+    possible_sources = ["MegaUp.net", "Rapidgator", "Mega.co.nz", "Mega.nz", "TusFiles", "KumpulBagi",
                         "UpFile", "FileCDN", "Go4Up (Multi Links)", "Uploaded", "Uptobox",
                         "Google Drive", "1Fichier", "Direct", "ClicknUpload", "AnonFiles"]  # Download Sources
     existing_sources = []

--- a/igg_scraper.py
+++ b/igg_scraper.py
@@ -89,7 +89,7 @@ def main():
 
                 for script in soup.find_all("script"):
                     matches = re.findall(
-                        r"Goroi_n_Create_Button\(\"(.*?)\"\)", script.text)
+                        r"Goroi_n_Create_Button\(\"(.*?)\"\)", str(script))
                     if(len(matches) > 0):
                         string = 'https://bluemediafiles.com/get-url.php?url=' + _bluemediafiles_decodeKey(matches[0])
                         third_req = urllib.request.Request(


### PR DESCRIPTION
The script variable was not a string before, therefore a regex search could not be performed and no direct links were printed.
When you use `script.text`, `matches` does not have any entries. That means that the `_bluemediafiles_decodeKey` function cannot decrypt anything as it does not have any string to work with.

Also a little typo in word 'build', some new hosts (openload.co removed as it is not available anymore) and some minor changes.